### PR TITLE
Fixing docker action to respect DOCKER_LATEST_BRANCH

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -153,8 +153,13 @@ func (d *Docker) Tag() string {
 // If branch "main" does not exist in repository, returns "master"
 // On any error, returns "master" to maintain original compatibility
 func (d *Docker) latestBranch() (latestBranch string) {
+	// If a user sets DOCKER_LATEST_BRANCH that should always be respected
+	latestBranch = d.Env.Get("DOCKER_LATEST_BRANCH")
+	if latestBranch != "" {
+		return
+	}
 	// Leaving "master" as default to maintain compatibility if checking git repo fails
-	latestBranch = d.Env.GetDefault("DOCKER_LATEST_BRANCH", "master")
+	latestBranch = "master"
 	repo, err := gogit.PlainOpen(".")
 	if err != nil {
 		return

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -152,39 +152,38 @@ func (d *Docker) Tag() string {
 // If DOCKER_LATEST_BRANCH is not defined, returns "main"
 // If branch "main" does not exist in repository, returns "master"
 // On any error, returns "master" to maintain original compatibility
-func (d *Docker) latestBranch() (latestBranch string) {
+func (d *Docker) latestBranch() string {
 	// If a user sets DOCKER_LATEST_BRANCH that should always be respected
-	latestBranch = d.Env.Get("DOCKER_LATEST_BRANCH")
-	if latestBranch != "" {
-		return
+	dockerLatestBranch := d.Env.Get("DOCKER_LATEST_BRANCH")
+	if dockerLatestBranch != "" {
+		return dockerLatestBranch
 	}
 	// Leaving "master" as default to maintain compatibility if checking git repo fails
-	latestBranch = "master"
+	oldDefaultBranch := "master"
 	repo, err := gogit.PlainOpen(".")
 	if err != nil {
-		return
+		return oldDefaultBranch
 	}
 	branches, err := repo.Branches()
 	if err != nil {
-		return
+		return oldDefaultBranch
 	}
 
 	// Return main if it exists, otherwise return master to maintain compatibility
 	for {
 		branch, err := branches.Next()
 		if err != nil {
-			return
+			return oldDefaultBranch
 		}
 		if branch == nil {
 			break
 		}
 		// Return "main" if that branch exists
 		if branch.Name().String() == "main" {
-			latestBranch = branch.Name().String()
-			return
+			return "main"
 		}
 	}
-	return
+	return oldDefaultBranch
 }
 
 //  If requireOnlyOne is set, then at most one result is returned. THis resolves a limitation of --cache-to

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -18,6 +18,8 @@ import (
 	gogit "github.com/go-git/go-git/v5"
 )
 
+const oldDefaultBranch string = "master"
+
 func trimLen(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s
@@ -159,7 +161,6 @@ func (d *Docker) latestBranch() string {
 		return dockerLatestBranch
 	}
 	// Leaving "master" as default to maintain compatibility if checking git repo fails
-	oldDefaultBranch := "master"
 	repo, err := gogit.PlainOpen(".")
 	if err != nil {
 		return oldDefaultBranch


### PR DESCRIPTION
Created in response to:
https://github.com/cresta/magehelper/pull/11/files/547ba72bcc3e3f77b59e2e35dc4d45caa8cc8b89#r664730664

@cep21 I think this will respect `DOCKER_LATEST_BRANCH` better.