### PR TITLE
Removing nakedret golint check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,7 +22,6 @@ linters:
     - maligned
     - megacheck
     - misspell
-    - nakedret
     - prealloc
     - scopelint
     - staticcheck


### PR DESCRIPTION
I mentioned this in https://github.com/cresta/magehelper/pull/12 but figured I'd just make a PR.

Naked returns with named variables are valid and useful, and can lend to much cleaner code when used correctly. I don't think we should block this feature of the language with a CI check ❤️.